### PR TITLE
fix rum_block item description

### DIFF
--- a/game/_script_/rooms/Main_Room/cupboard.rpy
+++ b/game/_script_/rooms/Main_Room/cupboard.rpy
@@ -92,7 +92,7 @@ label rum_block(item):
             ">You found a bottle of firewhisky from professor Dumbledore's personal stash..."
         else:
             ">You found [item.name]..."
-            ">[item.description]"
+            ">[item.desc]"
 
         call tutorial("inventory")
 


### PR DESCRIPTION
inventory item 'gift' contains field 'desc', but function with label 'rum_block' contains call >[item.descriptin], this make runtime exception when you get a random item from the closet.

call 'desc' fix this exception